### PR TITLE
Привести верстку sceneEditor к стилю

### DIFF
--- a/apps/qryleth-front/src/features/scene/ui/objectManager/SceneObjectManager.tsx
+++ b/apps/qryleth-front/src/features/scene/ui/objectManager/SceneObjectManager.tsx
@@ -514,7 +514,7 @@ export const SceneObjectManager: React.FC<ObjectManagerProps> = ({
             copyObject={handleCopyObject}
         >
         <>
-            <Paper shadow="sm" radius="md" p="sm" style={{ height: '100%' }}>
+            <Paper shadow="xs" withBorder radius="md" p="sm" style={{ height: '100%' }}>
                 <Stack gap="sm" style={{ height: '100%' }}>
                     <Title order={4} c="gray.6" size="md">
                         Сцена


### PR DESCRIPTION
Adjusted the right panel styling in SceneObjectManager to match the screenshot's 'card' style with lighter shadow and border.

---
<a href="https://cursor.com/background-agent?bcId=bc-a3a0f9bd-97c5-4b32-89d3-fcfd551f822a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a3a0f9bd-97c5-4b32-89d3-fcfd551f822a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

