### PR TITLE
Исправление путей SceneEditorR3F и Scene3D в документации

### DIFF
--- a/docs/features/scene-management/README.md
+++ b/docs/features/scene-management/README.md
@@ -23,7 +23,7 @@ See [Feature-Sliced Design](../../architecture/feature-sliced-design.md) for det
 ## Основные компоненты
 
 ### 🎬 SceneEditorR3F
-**Location**: `src/pages/SceneEditor/SceneEditorR3F.tsx`
+**Location**: `src/features/scene/ui/SceneEditorR3F.tsx`
 
 Основной компонент редактора сцен, который координирует всю функциональность редактирования сцен.
 
@@ -35,7 +35,7 @@ See [Feature-Sliced Design](../../architecture/feature-sliced-design.md) for det
 - Предоставляет функциональность отмены/повтора
 
 ### 🎨 Scene3D
-**Location**: `src/features/scene/ui/Scene3D.tsx`
+**Location**: `src/features/scene/ui/renderer/Scene3D.tsx`
 
 Компонент канваса Three.js, ответственный за 3D рендеринг и визуализацию.
 


### PR DESCRIPTION
## Summary
- Обновлены ссылки на файлы SceneEditorR3F и Scene3D в документации по управлению сценой

## Testing
- `npm test` *(failed: TypeError: ctx.clearRect is not a function; DexieError: IndexedDB API missing; AssertionError: expected -1 to be close to 1)*
- `npm run lint` *(failed: 319 problems (297 errors, 22 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68af5f1cb63c8320a875a587833103e3